### PR TITLE
Stop passing --fhip-new-launch-api to Clang

### DIFF
--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -1093,7 +1093,6 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
                                   + deviceLibPath + "\"";
       HIPCXXFLAGS += hip_device_lib_str;
     }
-    HIPCXXFLAGS += " -fhip-new-launch-api";
   }
   if (os != windows) {
     HIPLDFLAGS += " -lgcc_s -lgcc -lpthread -lm -lrt";


### PR DESCRIPTION
hip-new-launch-api is clang's default when compiling HIP so this is redundant.