### PR TITLE
Build binaries to bin directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project (hipcc.bin)
 # Specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set (EXECUTABLE_OUTPUT_PATH "bin")
 
 set (LINK_LIBS libstdc++fs.so)
 add_executable(hipcc.bin src/hipBin.cpp)


### PR DESCRIPTION
While enabling HIPCC builds in AMD-Radeon-Driver/compute we've run into an issue where we need HIPCC to build it's resulting binaries/executables in a 'bin' directory.; specifically this PR: https://github.amd.com/AMD-Radeon-Driver/compute/pull/153

This may have impacts on other build scripts.
