### PR TITLE
SWDEV-326661 - device_lib_path, return error code when build fails

### DIFF
--- a/src/hipBin.cpp
+++ b/src/hipBin.cpp
@@ -112,6 +112,7 @@ void HipBin::executeHipBin(string filename, int argc, char* argv[]) {
     cout << "Command " << filename
     << " not supported. Name the exe as hipconfig"
     << " or hipcc and then try again ..." << endl;
+    exit(-1);
   }
 }
 

--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -359,12 +359,12 @@ string HipBinAmd::getCppConfig() {
 }
 
 string HipBinAmd::getDeviceLibPath() const {
-  string deviceLibPath;
   const EnvVariables& var = getEnvVariables();
   const string& rocclrHomePath = getRocclrHomePath();
   const string& roccmPath = getRoccmPath();
   fs::path bitCodePath = rocclrHomePath;
   bitCodePath /= "lib/bitcode";
+  string deviceLibPath = var.deviceLibPathEnv_;
   if (var.deviceLibPathEnv_.empty() && fs::exists(bitCodePath)) {
     deviceLibPath = bitCodePath.string();
   }
@@ -1160,20 +1160,8 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
     sysOut = hipBinUtilPtr_->exec(CMD.c_str(), true);
     string cmdOut = sysOut.out;
     int CMD_EXIT_CODE = sysOut.exitCode;
-    if (CMD_EXIT_CODE == -1) {
-      cout <<  "failed to execute: $!\n";
-    } else if (CMD_EXIT_CODE & 127) {
-      string childOut;
-      int childCode;
-      (CMD_EXIT_CODE & 127),  (CMD_EXIT_CODE & 128) ?
-              childOut = "with" : childOut = "without";
-      (CMD_EXIT_CODE & 127),  (CMD_EXIT_CODE & 128) ?
-              childCode = (CMD_EXIT_CODE & 127) :
-              childCode = (CMD_EXIT_CODE & 128);
-      cout <<  "child died with signal " << childCode << "," << childOut <<
-                          " coredump "<< " for cmd: " << CMD << endl;
-    } else {
-      CMD_EXIT_CODE = CMD_EXIT_CODE >> 8;
+    if (CMD_EXIT_CODE !=0) {
+      cout <<  "failed to execute:"  << CMD << std::endl;
     }
     exit(CMD_EXIT_CODE);
   }  // end of runCmd section

--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -365,7 +365,7 @@ string HipBinAmd::getDeviceLibPath() const {
   fs::path bitCodePath = rocclrHomePath;
   bitCodePath /= "lib/bitcode";
   string deviceLibPath = var.deviceLibPathEnv_;
-  if (var.deviceLibPathEnv_.empty() && fs::exists(bitCodePath)) {
+  if (deviceLibPath.empty() && fs::exists(bitCodePath)) {
     deviceLibPath = bitCodePath.string();
   }
 

--- a/src/hipBin_nvidia.h
+++ b/src/hipBin_nvidia.h
@@ -591,20 +591,8 @@ void HipBinNvidia::executeHipCCCmd(vector<string> argv) {
     sysOut = hipBinUtilPtr_->exec(CMD.c_str(), true);
     string cmdOut = sysOut.out;
     int CMD_EXIT_CODE = sysOut.exitCode;
-    if (CMD_EXIT_CODE == -1) {
-      cout <<  "failed to execute: $!\n";
-    } else if (CMD_EXIT_CODE & 127) {
-      string childOut;
-      int childCode;
-      (CMD_EXIT_CODE & 127),  (CMD_EXIT_CODE & 128) ?
-                              childOut = "with" : childOut = "without";
-      (CMD_EXIT_CODE & 127),  (CMD_EXIT_CODE & 128) ?
-                              childCode = (CMD_EXIT_CODE & 127) :
-                              childCode = (CMD_EXIT_CODE & 128);
-      cout <<  "child died with signal " << childCode << "," <<
-      childOut << " coredump "<< " for cmd: " << CMD << endl;
-    } else {
-      CMD_EXIT_CODE = CMD_EXIT_CODE >> 8;
+    if (CMD_EXIT_CODE !=0) {
+      cout <<  "failed to execute:"  << CMD << std::endl;
     }
     exit(CMD_EXIT_CODE);
   }


### PR DESCRIPTION
hipcc cpp to return failure code.  Fix to use devicelibpath when env variable is available 

Change-Id: Idca31dedf3b5ce1524fc344a47a3c96afde562ad