### PR TITLE
Handle file reorganization changes in Rocm path construction

### DIFF
--- a/src/hipBin_base.h
+++ b/src/hipBin_base.h
@@ -333,12 +333,18 @@ void HipBinBase::constructHipPath() {
 void HipBinBase::constructRoccmPath() {
   if (envVariables_.roccmPathEnv_.empty()) {
     const string& hipPath = getHipPath();
+    //File reorg hip path is /opt/rocm-ver
     fs::path roccm_path(hipPath);
-    roccm_path = roccm_path.parent_path();
     fs::path rocm_agent_enumerator_file(roccm_path);
     rocm_agent_enumerator_file /= "bin/rocm_agent_enumerator";
     if (!fs::exists(rocm_agent_enumerator_file)) {
-      roccm_path = "/opt/rocm";
+      //Backward compatibility hip path is /opt/rocm-ver/hip
+      roccm_path = roccm_path.parent_path();
+      rocm_agent_enumerator_file = roccm_path;
+      rocm_agent_enumerator_file /= "bin/rocm_agent_enumerator";
+      if (!fs::exists(rocm_agent_enumerator_file)) {
+        roccm_path = "/opt/rocm";
+      }
     }
     variables_.roccmPathEnv_ = roccm_path.string();
   } else {


### PR DESCRIPTION
File reorganized hip path will be /opt/rocm-ver.
Handle this use case during rocm path construction with backward compatibility 