### PR TITLE
Remove code that sets -std and -fms-* flags

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,0 +1,110 @@
+def hipBuildTest(String backendLabel) {
+        node(backendLabel) {
+          stage("Source sync ${backendLabel}") {
+
+            // Checkout hip repository with the PR patch
+            dir("${WORKSPACE}/HIPCC") {
+                   checkout scm
+                   env.HIPCC_DIR = "${WORKSPACE}" + "/HIPCC"
+            }
+            
+            // Clone HIP repository
+            dir("${WORKSPACE}/hip") {
+               git branch: 'develop',
+               url: 'https://github.com/ROCm-Developer-Tools/HIP'
+               env.HIP_DIR = "${WORKSPACE}" + "/hip"
+            }
+
+            // Clone hipamd repository
+            dir("${WORKSPACE}/hipamd") {
+              git branch: 'develop',
+              url: 'https://github.com/ROCm-Developer-Tools/hipamd'
+            }
+
+            // Clone vdi and opencl for only amd backend server
+            if (backendLabel =~ /.*amd.*/) {  
+               dir("${WORKSPACE}/ROCm-OpenCL-Runtime") {
+                   git branch:'develop',
+                   url: 'https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime'
+                   env.OPENCL_DIR = "${WORKSPACE}" + "/ROCm-OpenCL-Runtime"
+               }
+               dir("${WORKSPACE}/ROCclr") {
+                   git branch:'develop',
+                   url: 'https://github.com/ROCm-Developer-Tools/ROCclr'
+                   env.ROCclr_DIR = "${WORKSPACE}" + "/ROCclr"
+               }
+            }
+        }
+
+        stage("Build - HIPCC") {
+            // Running the build on HIPCC workspace
+            dir("${WORKSPACE}/HIPCC") {
+                sh  """#!/usr/bin/env bash
+                    set -x
+                    rm -rf build
+                    mkdir build
+                    cd build/
+                    cmake ..
+                    make
+                    """
+            }
+        }
+
+        stage("Build - Catch2 framework") {
+            // Running the build on hipamd workspace
+            dir("${WORKSPACE}/hipamd") {
+                sh  """#!/usr/bin/env bash
+                    set -x
+                    mkdir -p build
+                    cd build
+                    # Check if backend label contains string "amd" or backend host is a server with amd gpu
+                    if [[ $backendLabel =~ amd ]]; then
+                        cmake -DHIP_CATCH_TEST=1 -DHIP_PATH=\$PWD/install -DHIPCC_BIN_DIR=\$HIPCC_DIR/build -DHIP_COMMON_DIR=\$HIP_DIR -DAMD_OPENCL_PATH=\$OPENCL_DIR -DROCCLR_PATH=\$ROCclr_DIR -DCMAKE_PREFIX_PATH="/opt/rocm/" -DCMAKE_INSTALL_PREFIX=\$PWD/install ..
+                    else
+                        export HIP_PLATFORM=nvidia
+                        export HIP_COMPILER=nvcc
+                        export HIP_RUNTIME=cuda
+                        cmake -DHIP_CATCH_TEST=1 -DHIP_PATH=\$PWD/install -DHIPCC_BIN_DIR=\$HIPCC_DIR/build -DHIP_COMMON_DIR=$HIP_DIR -DCMAKE_INSTALL_PREFIX=\$PWD/install ..
+                    fi
+                    make install  -j\$(nproc)
+                    if [[ $backendLabel =~ amd ]]; then
+                        make build_tests  -j\$(nproc)
+                    else
+                        HIP_COMPILER=nvcc HIP_PLATFORM=nvidia make build_tests -j\$(nproc)
+                    fi
+                    """
+            }
+        }
+
+        stage('HIP Unit Tests - Catch2 framework') {
+            dir("${WORKSPACE}/hipamd/build") {
+                sh  """#!/usr/bin/env bash
+                    set -x
+                    # Check if backend label contains string "amd" or backend host is a server with amd gpu
+                    if [[ $backendLabel =~ amd ]]; then
+                        LLVM_PATH=/opt/rocm/llvm ctest -E 'Unit_hiprtc_saxpy'
+                    else
+                        make test
+                    fi
+                    """
+            }
+        }
+    }
+}
+
+timestamps {
+    node('external-bootstrap') {
+        skipDefaultCheckout()
+
+        // labels belonging to each backend - AMD, NVIDIA
+        String[] labels = ['hip-amd-vg20-ubu1804', 'hip-nvidia-rtx5000-ubu1804']
+        buildMap = [:]
+
+        labels.each { backendLabel ->
+            echo "backendLabel: ${backendLabel}"
+            buildMap[backendLabel] = { hipBuildTest(backendLabel) }
+        }
+        buildMap['failFast'] = false
+        parallel  buildMap
+    }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16.3)
 project (hipcc.bin)
 
-# specify the C++ standard
+# Specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set (LINK_LIBS libstdc++fs.so)
 add_executable(hipcc.bin src/hipBin.cpp)
-if (NOT WIN32) # c++17 does not require the std lib linking
+if (NOT WIN32) # C++17 does not require the std lib linking
   target_link_libraries(hipcc.bin ${LINK_LIBS} ) # for hipcc.bin
 endif()
 
 project (hipconfig.bin)
 add_executable(hipconfig.bin src/hipBin.cpp)
-if (NOT WIN32) # c++17 does not require the std lib linking
+if (NOT WIN32) # C++17 does not require the std lib linking
   target_link_libraries(hipconfig.bin ${LINK_LIBS} ) # for hipconfig.bin
 endif()
 

--- a/src/hipBin.cpp
+++ b/src/hipBin.cpp
@@ -112,6 +112,7 @@ void HipBin::executeHipBin(string filename, int argc, char* argv[]) {
     cout << "Command " << filename
     << " not supported. Name the exe as hipconfig"
     << " or hipcc and then try again ..." << endl;
+    exit(-1);
   }
 }
 

--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -203,11 +203,6 @@ string HipBinAmd::getHipInclude() const {
 void HipBinAmd::initializeHipCXXFlags() {
   string hipCXXFlags;
   const OsType& os = getOSInfo();
-  if (os == windows) {
-    hipCXXFlags = " -std=c++14 -fms-extensions -fms-compatibility";
-  } else {
-    hipCXXFlags = " -std=c++11";
-  }
   string hipClangIncludePath;
   hipClangIncludePath = getCompilerIncludePath();
   hipCXXFlags += " -isystem \"" + hipClangIncludePath;

--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -359,13 +359,13 @@ string HipBinAmd::getCppConfig() {
 }
 
 string HipBinAmd::getDeviceLibPath() const {
-  string deviceLibPath;
   const EnvVariables& var = getEnvVariables();
   const string& rocclrHomePath = getRocclrHomePath();
   const string& roccmPath = getRoccmPath();
   fs::path bitCodePath = rocclrHomePath;
   bitCodePath /= "lib/bitcode";
-  if (var.deviceLibPathEnv_.empty() && fs::exists(bitCodePath)) {
+  string deviceLibPath = var.deviceLibPathEnv_;
+  if (deviceLibPath.empty() && fs::exists(bitCodePath)) {
     deviceLibPath = bitCodePath.string();
   }
 
@@ -1160,20 +1160,8 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
     sysOut = hipBinUtilPtr_->exec(CMD.c_str(), true);
     string cmdOut = sysOut.out;
     int CMD_EXIT_CODE = sysOut.exitCode;
-    if (CMD_EXIT_CODE == -1) {
-      cout <<  "failed to execute: $!\n";
-    } else if (CMD_EXIT_CODE & 127) {
-      string childOut;
-      int childCode;
-      (CMD_EXIT_CODE & 127),  (CMD_EXIT_CODE & 128) ?
-              childOut = "with" : childOut = "without";
-      (CMD_EXIT_CODE & 127),  (CMD_EXIT_CODE & 128) ?
-              childCode = (CMD_EXIT_CODE & 127) :
-              childCode = (CMD_EXIT_CODE & 128);
-      cout <<  "child died with signal " << childCode << "," << childOut <<
-                          " coredump "<< " for cmd: " << CMD << endl;
-    } else {
-      CMD_EXIT_CODE = CMD_EXIT_CODE >> 8;
+    if (CMD_EXIT_CODE !=0) {
+      cout <<  "failed to execute:"  << CMD << std::endl;
     }
     exit(CMD_EXIT_CODE);
   }  // end of runCmd section

--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -1093,7 +1093,6 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
                                   + deviceLibPath + "\"";
       HIPCXXFLAGS += hip_device_lib_str;
     }
-    HIPCXXFLAGS += " -fhip-new-launch-api";
   }
   if (os != windows) {
     HIPLDFLAGS += " -lgcc_s -lgcc -lpthread -lm -lrt";

--- a/src/hipBin_nvidia.h
+++ b/src/hipBin_nvidia.h
@@ -591,20 +591,8 @@ void HipBinNvidia::executeHipCCCmd(vector<string> argv) {
     sysOut = hipBinUtilPtr_->exec(CMD.c_str(), true);
     string cmdOut = sysOut.out;
     int CMD_EXIT_CODE = sysOut.exitCode;
-    if (CMD_EXIT_CODE == -1) {
-      cout <<  "failed to execute: $!\n";
-    } else if (CMD_EXIT_CODE & 127) {
-      string childOut;
-      int childCode;
-      (CMD_EXIT_CODE & 127),  (CMD_EXIT_CODE & 128) ?
-                              childOut = "with" : childOut = "without";
-      (CMD_EXIT_CODE & 127),  (CMD_EXIT_CODE & 128) ?
-                              childCode = (CMD_EXIT_CODE & 127) :
-                              childCode = (CMD_EXIT_CODE & 128);
-      cout <<  "child died with signal " << childCode << "," <<
-      childOut << " coredump "<< " for cmd: " << CMD << endl;
-    } else {
-      CMD_EXIT_CODE = CMD_EXIT_CODE >> 8;
+    if (CMD_EXIT_CODE !=0) {
+      cout <<  "failed to execute:"  << CMD << std::endl;
     }
     exit(CMD_EXIT_CODE);
   }


### PR DESCRIPTION
Code was a workaround; no longer needed; rely instead on the clang defaults.
