### PR TITLE
Remove code that sets -std and -fms-* flags

### DIFF
--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -203,11 +203,6 @@ string HipBinAmd::getHipInclude() const {
 void HipBinAmd::initializeHipCXXFlags() {
   string hipCXXFlags;
   const OsType& os = getOSInfo();
-  if (os == windows) {
-    hipCXXFlags = " -std=c++14 -fms-extensions -fms-compatibility";
-  } else {
-    hipCXXFlags = " -std=c++11";
-  }
   string hipClangIncludePath;
   hipClangIncludePath = getCompilerIncludePath();
   hipCXXFlags += " -isystem \"" + hipClangIncludePath;


### PR DESCRIPTION
Code was a workaround; no longer needed; rely instead on the clang defaults.