### PR TITLE
SWDEV-355608 - hipcc: remove -use_fast_math

### DIFF
--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -689,10 +689,6 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
       compileOnly = 1;
       buildDeps = 1;
     }
-    if (trimarg == "-use_fast_math") {
-      HIPCXXFLAGS += " -DHIP_FAST_MATH ";
-      HIPCFLAGS += " -DHIP_FAST_MATH ";
-    }
     if ((trimarg == "-use-staticlib") && (setLinkType == 0)) {
       linkType = 0;
       setLinkType = 1;


### PR DESCRIPTION
It doesn't seem to provide any functionality, probably leftover from some experimental codes.