### PR TITLE
SWDEV-355608 - Remove clang include path

### DIFF
--- a/src/hipBin_base.h
+++ b/src/hipBin_base.h
@@ -213,7 +213,6 @@ class HipBinBase {
   virtual const string& getCompilerPath() const = 0;
   virtual void printCompilerInfo() const = 0;
   virtual string getCompilerVersion() = 0;
-  virtual string getCompilerIncludePath() = 0;
   virtual const PlatformInfo& getPlatformInfo() const = 0;
   virtual string getCppConfig() = 0;
   virtual void checkHipconfig() = 0;


### PR DESCRIPTION
Clang doesn't need to be told where to find the clang headers

Change-Id: I2d1e84b31013aa6668efd2ff096f5e68f9ba9a64