### PR TITLE
SWDEV-355608 - deprecate/cleanup hipcc link flags

### DIFF
--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -147,19 +147,12 @@ const string& HipBinAmd::getHipLdFlags() const {
 
 
 void HipBinAmd::initializeHipLdFlags() {
-  string hipLibPath;
   string hipLdFlags;
   const string& hipClangPath = getCompilerPath();
   // If $HIPCC clang++ is not compiled, use clang instead
   string hipCC = "\"" + hipClangPath + "/clang++";
   if (!fs::exists(hipCC)) {
     hipLdFlags = "--driver-mode=g++";
-  }
-  hipLibPath = getHipLibPath();
-  hipLdFlags += " -L\"" + hipLibPath + "\"";
-  const OsType& os = getOSInfo();
-  if (os == windows) {
-    hipLdFlags += " -lamdhip64";
   }
   hipLdFlags_ = hipLdFlags;
 }
@@ -543,8 +536,6 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
   bool printLDFlags = 0;       // print HIPLDFLAGS
   bool runCmd = 1;
   bool buildDeps = 0;
-  bool linkType = 1;
-  bool setLinkType = 0;
   string hsacoVersion;
   bool funcSupp = 0;      // enable function support
   bool rdc = 0;           // whether -fgpu-rdc is on
@@ -693,14 +684,11 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
       compileOnly = 1;
       buildDeps = 1;
     }
-    if ((trimarg == "-use-staticlib") && (setLinkType == 0)) {
-      linkType = 0;
-      setLinkType = 1;
-      swallowArg = 1;
+    if (trimarg == "-use-staticlib") {
+      cout << "Warning: The -use-staticlib option has been deprecated and is no longer needed.\n";
     }
-    if ((trimarg == "-use-sharedlib") && (setLinkType == 0)) {
-      linkType = 1;
-      setLinkType = 1;
+    if (trimarg == "-use-sharedlib") {
+      cout << "Warning: The -use-sharedlib option has been deprecated and is no longer needed.\n";
     }
     if (hipBinUtilPtr_->stringRegexMatch(arg, "^-O.*")) {
       optArg = arg;
@@ -1052,11 +1040,6 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
   if (buildDeps) {
     HIPCXXFLAGS += " --cuda-host-only";
   }
-  // Add --hip-link only if it is compile only and -fgpu-rdc is on.
-  if (rdc && !compileOnly) {
-    HIPLDFLAGS += " --hip-link";
-    HIPLDFLAGS += HIPLDARCHFLAGS;
-  }
 
   // hipcc currrently requires separate compilation of source files,
   // ie it is not possible to pass
@@ -1090,26 +1073,15 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
       HIPCXXFLAGS += hip_device_lib_str;
     }
   }
-  if (os != windows) {
-    HIPLDFLAGS += " -lgcc_s -lgcc -lpthread -lm -lrt";
-  }
 
-  if (os != windows && !compileOnly) {
-    string hipClangVersion, toolArgTemp;
-    if (linkType == 0) {
-      toolArgTemp = " -L"+ hipLibPath + "-lamdhip64 -L" +
-                      roccmPath+ "/lib -lhsa-runtime64 -ldl -lnuma " + toolArgs;
-      toolArgs = toolArgTemp;
-    } else {
-      toolArgTemp =  toolArgs + " -Wl,-rpath=" + hipLibPath + ":"
-                    + roccmPath+"/lib -lamdhip64 ";
-      toolArgs =  toolArgTemp;
+  if (!compileOnly) {
+    HIPLDFLAGS += " --hip-link";
+    if (os == windows) {
+      string hipClangVersion = getCompilerVersion();
+      // To support __fp16 and _Float16, explicitly link with compiler-rt
+      toolArgs += " -L" + hipClangPath + "/../lib/clang/" +
+                  hipClangVersion + "/lib/linux -lclang_rt.builtins-x86_64 ";
     }
-
-    hipClangVersion = getCompilerVersion();
-    // To support __fp16 and _Float16, explicitly link with compiler-rt
-    toolArgs += " -L" + hipClangPath + "/../lib/clang/" +
-                hipClangVersion + "/lib/linux -lclang_rt.builtins-x86_64 ";
   }
   if (!var.hipccCompileFlagsAppendEnv_.empty()) {
     HIPCXXFLAGS += " " + var.hipccCompileFlagsAppendEnv_ + " ";


### PR DESCRIPTION
- deprecate -use-staticlib, -use-sharedlib which no longer provide any functional values
- use --hip-link instead of specifying the HIP runtime by name when linking

Change-Id: I8e69127b5913b445a7a622b8d3fc8e15944fd869