### PR TITLE
SWDEV-344613 - hipcc fails when runtime is installed in /usr

### DIFF
--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -164,17 +164,6 @@ void HipBinAmd::initializeHipLdFlags() {
 }
 
 void HipBinAmd::initializeHipCFlags() {
-  string hipCFlags;
-  const OsType& os = getOSInfo();
-  if (os != windows) {
-    string hsaPath;
-    hsaPath = getHsaPath();
-    hipCFlags += " -isystem " + hsaPath + "/include";
-  }
-  string hipIncludePath;
-  hipIncludePath = getHipInclude();
-  hipCFlags += " -isystem \"" + hipIncludePath + "\"";
-  hipCFlags_ = hipCFlags;
 }
 
 const string& HipBinAmd::getHipCXXFlags() const {
@@ -206,14 +195,6 @@ void HipBinAmd::initializeHipCXXFlags() {
     " -Xclang -fallow-half-arguments-and-returns -D__HIP_HCC_COMPAT_MODE__=1";
   }
 
-  if (os != windows) {
-    const string& hsaPath = getHsaPath();
-    hipCXXFlags += " -isystem " + hsaPath + "/include";
-  }
-  // Add paths to common HIP includes:
-  string hipIncludePath;
-  hipIncludePath = getHipInclude();
-  hipCXXFlags += " -isystem \"" + hipIncludePath + "\"";
   hipCXXFlags_ = hipCXXFlags;
 }
 
@@ -538,7 +519,6 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
   string HIPLDARCHFLAGS;
 
   initializeHipCXXFlags();
-  initializeHipCFlags();
   initializeHipLdFlags();
   string HIPCXXFLAGS, HIPCFLAGS, HIPLDFLAGS;
   HIPCFLAGS = getHipCFlags();


### PR DESCRIPTION
Remove all -isystem options from compiler calls for hipcc