### PR TITLE
SWDEV-355608 - deprecate/cleanup hipcc link flags

### DIFF
--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -25,11 +25,11 @@ THE SOFTWARE.
 
 #include "hipBin_base.h"
 #include "hipBin_util.h"
-#include <vector>
+#include <cassert>
+#include <iostream>
 #include <string>
 #include <unordered_set>
-#include <cassert>
-
+#include <vector>
 
 // Use (void) to silent unused warnings.
 #define assertm(exp, msg) assert(((void)msg, exp))
@@ -62,7 +62,6 @@ class HipBinAmd : public HipBinBase {
   virtual string getCompilerVersion();
   virtual void checkHipconfig();
   virtual string getDeviceLibPath() const;
-  virtual string getHipLibPath() const;
   virtual string getHipCC() const;
   virtual string getHipInclude() const;
   virtual void initializeHipCXXFlags();
@@ -146,19 +145,12 @@ const string& HipBinAmd::getHipLdFlags() const {
 
 
 void HipBinAmd::initializeHipLdFlags() {
-  string hipLibPath;
   string hipLdFlags;
   const string& hipClangPath = getCompilerPath();
   // If $HIPCC clang++ is not compiled, use clang instead
   string hipCC = "\"" + hipClangPath + "/clang++";
   if (!fs::exists(hipCC)) {
     hipLdFlags = "--driver-mode=g++";
-  }
-  hipLibPath = getHipLibPath();
-  hipLdFlags += " -L\"" + hipLibPath + "\"";
-  const OsType& os = getOSInfo();
-  if (os == windows) {
-    hipLdFlags += " -lamdhip64";
   }
   hipLdFlags_ = hipLdFlags;
 }
@@ -387,26 +379,6 @@ bool HipBinAmd::detectPlatform() {
   return detected;
 }
 
-
-
-string HipBinAmd::getHipLibPath() const {
-  string hipLibPath;
-  const EnvVariables& env = getEnvVariables();
-  if (env.hipLibPathEnv_.empty()) {
-    const string& rocclrHomePath = getRocclrHomePath();
-    fs::path libPath = rocclrHomePath;
-    libPath /= "lib";
-    hipLibPath = libPath.string();
-  }
-  if (hipLibPath.empty()) {
-    const string& hipPath = getHipPath();
-    fs::path libPath = hipPath;
-    libPath /= "lib";
-    hipLibPath = libPath.string();
-  }
-  return hipLibPath;
-}
-
 string HipBinAmd::getHipCC() const {
   string hipCC;
   const string& hipClangPath = getCompilerPath();
@@ -507,8 +479,6 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
   bool printLDFlags = 0;       // print HIPLDFLAGS
   bool runCmd = 1;
   bool buildDeps = 0;
-  bool linkType = 1;
-  bool setLinkType = 0;
   string hsacoVersion;
   bool funcSupp = 0;      // enable function support
   bool rdc = 0;           // whether -fgpu-rdc is on
@@ -544,9 +514,7 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
   HIPCFLAGS = getHipCFlags();
   HIPCXXFLAGS = getHipCXXFlags();
   HIPLDFLAGS = getHipLdFlags();
-  string hipLibPath;
   string hipIncludePath, deviceLibPath;
-  hipLibPath = getHipLibPath();
   const string& roccmPath = getRoccmPath();
   const string& hipPath = getHipPath();
   const PlatformInfo& platformInfo = getPlatformInfo();
@@ -564,7 +532,6 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
     cout << "HIP_ROCCLR_HOME="<< rocclrHomePath << endl;
     cout << "HIP_CLANG_PATH=" << hipClangPath <<endl;
     cout << "HIP_INCLUDE_PATH="<< hipIncludePath  <<endl;
-    cout << "HIP_LIB_PATH="<< hipLibPath <<endl;
     cout << "DEVICE_LIB_PATH="<< deviceLibPath <<endl;
   }
 
@@ -655,14 +622,13 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
       compileOnly = 1;
       buildDeps = 1;
     }
-    if ((trimarg == "-use-staticlib") && (setLinkType == 0)) {
-      linkType = 0;
-      setLinkType = 1;
-      swallowArg = 1;
+    if ((trimarg == "-use-staticlib")) {
+      std::cerr << "Warning: The -use-staticlib option has been deprecated and is no longer needed.\n";
+      swallowArg = true;
     }
-    if ((trimarg == "-use-sharedlib") && (setLinkType == 0)) {
-      linkType = 1;
-      setLinkType = 1;
+    if ((trimarg == "-use-sharedlib")) {
+      std::cerr << "Warning: The -use-sharedlib option has been deprecated and is no longer needed.\n";
+      swallowArg = true;
     }
     if (hipBinUtilPtr_->stringRegexMatch(arg, "^-O.*")) {
       optArg = arg;
@@ -1014,11 +980,6 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
   if (buildDeps) {
     HIPCXXFLAGS += " --cuda-host-only";
   }
-  // Add --hip-link only if it is compile only and -fgpu-rdc is on.
-  if (rdc && !compileOnly) {
-    HIPLDFLAGS += " --hip-link";
-    HIPLDFLAGS += HIPLDARCHFLAGS;
-  }
 
   // hipcc currrently requires separate compilation of source files,
   // ie it is not possible to pass
@@ -1052,27 +1013,19 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
       HIPCXXFLAGS += hip_device_lib_str;
     }
   }
-  if (os != windows) {
-    HIPLDFLAGS += " -lgcc_s -lgcc -lpthread -lm -lrt";
-  }
 
-  if (os != windows && !compileOnly) {
-    string hipClangVersion, toolArgTemp;
-    if (linkType == 0) {
-      toolArgTemp = " -L"+ hipLibPath + "-lamdhip64 -L" +
-                      roccmPath+ "/lib -lhsa-runtime64 -ldl -lnuma " + toolArgs;
-      toolArgs = toolArgTemp;
-    } else {
-      toolArgTemp =  toolArgs + " -Wl,-rpath=" + hipLibPath + ":"
-                    + roccmPath+"/lib -lamdhip64 ";
-      toolArgs =  toolArgTemp;
+  if (!compileOnly) {
+    HIPLDFLAGS += " --hip-link";
+    if (rdc) {
+      HIPLDFLAGS += HIPLDARCHFLAGS;
     }
-
-    hipClangVersion = getCompilerVersion();
-    // To support __fp16 and _Float16, explicitly link with compiler-rt
-    toolArgs += " -L" + hipClangPath + "/../lib/clang/" +
-                hipClangVersion + "/lib/linux -lclang_rt.builtins-x86_64 ";
+    if (os != windows) {
+      // To support __fp16 and _Float16, explicitly link with compiler-rt
+      toolArgs += " -L" + hipClangPath + "/../lib/clang/" +
+                  getCompilerVersion() + "/lib/linux -lclang_rt.builtins-x86_64 ";
+    }
   }
+
   if (!var.hipccCompileFlagsAppendEnv_.empty()) {
     HIPCXXFLAGS += " " + var.hipccCompileFlagsAppendEnv_ + " ";
     HIPCFLAGS += " " + var.hipccCompileFlagsAppendEnv_ + " ";

--- a/src/hipBin_base.h
+++ b/src/hipBin_base.h
@@ -217,7 +217,6 @@ class HipBinBase {
   virtual string getCppConfig() = 0;
   virtual void checkHipconfig() = 0;
   virtual string getDeviceLibPath() const = 0;
-  virtual string getHipLibPath() const = 0;
   virtual string getHipCC() const = 0;
   virtual string getHipInclude() const = 0;
   virtual void initializeHipCXXFlags() = 0;

--- a/src/hipBin_nvidia.h
+++ b/src/hipBin_nvidia.h
@@ -48,7 +48,6 @@ class HipBinNvidia : public HipBinBase {
   virtual string getCompilerVersion();
   virtual void checkHipconfig();
   virtual string getDeviceLibPath() const;
-  virtual string getHipLibPath() const;
   virtual string getHipCC() const;
   virtual string getCompilerIncludePath();
   virtual string getHipInclude() const;
@@ -216,14 +215,6 @@ void HipBinNvidia::initializeHipCXXFlags() {
   hipIncludePath = getHipInclude();
   hipCXXFlags += " -isystem \"" + hipIncludePath + "\"";
   hipCXXFlags_ = hipCXXFlags;
-}
-
-// returns Hip Lib Path
-string HipBinNvidia::getHipLibPath() const {
-  string hipLibPath;
-  const EnvVariables& env = getEnvVariables();
-  hipLibPath = env.hipLibPathEnv_;
-  return hipLibPath;
 }
 
 // gets nvcc compiler Path


### PR DESCRIPTION
- deprecate -use-staticlib, -use-sharedlib which no longer provide any functional values
- use --hip-link instead of specifying the HIP runtime by name when linking
- fix linker option bug in HIT test's cmake
- update build options for unit tests requiring pthread or rt

ported from http://gerrit-git.amd.com/c/compute/ec/hip/+/741505