### PR TITLE
SWDEV-379927 - ignore passing --rocm-path=xxxxx to nvcc nvidia platform

### DIFF
--- a/src/hipBin_nvidia.h
+++ b/src/hipBin_nvidia.h
@@ -375,7 +375,9 @@ void HipBinNvidia::executeHipCCCmd(vector<string> argv) {
     for (unsigned int i = 2; i < argv.size(); i++) {
       string isaarg = argv.at(i);
       ISACMD += " ";
-      ISACMD += isaarg;
+      if (!hipBinUtilPtr_->substringPresent(isaarg,"--rocm-path=")) {
+        ISACMD += isaarg;
+      }
     }
     if (verbose & 0x1) {
       cout<< "hipcc-cmd: " << ISACMD << "\n";


### PR DESCRIPTION
SWDEV-379927 - ignore passing --rocm-path=xxxxx to nvcc nvidia platform

Skip passing --rocm-path to nvcc as  nvcc does not understand rocm or need rocm-path for building apps