### PR TITLE
SWDEV-355608 - deprecate/cleanup hipcc link flags

### DIFF
--- a/src/hipBin_amd.h
+++ b/src/hipBin_amd.h
@@ -144,19 +144,12 @@ const string& HipBinAmd::getHipLdFlags() const {
 
 
 void HipBinAmd::initializeHipLdFlags() {
-  string hipLibPath;
   string hipLdFlags;
   const string& hipClangPath = getCompilerPath();
   // If $HIPCC clang++ is not compiled, use clang instead
   string hipCC = "\"" + hipClangPath + "/clang++";
   if (!fs::exists(hipCC)) {
     hipLdFlags = "--driver-mode=g++";
-  }
-  hipLibPath = getHipLibPath();
-  hipLdFlags += " -L\"" + hipLibPath + "\"";
-  const OsType& os = getOSInfo();
-  if (os == windows) {
-    hipLdFlags += " -lamdhip64";
   }
   hipLdFlags_ = hipLdFlags;
 }
@@ -385,17 +378,13 @@ bool HipBinAmd::detectPlatform() {
 string HipBinAmd::getHipLibPath() const {
   string hipLibPath;
   const EnvVariables& env = getEnvVariables();
-  if (env.hipLibPathEnv_.empty()) {
-    const string& rocclrHomePath = getRocclrHomePath();
-    fs::path libPath = rocclrHomePath;
-    libPath /= "lib";
-    hipLibPath = libPath.string();
+  if (!env.hipLibPathEnv_.empty()) {
+    hipLibPath = env.hipLibPathEnv_;
   }
-  if (hipLibPath.empty()) {
-    const string& hipPath = getHipPath();
-    fs::path libPath = hipPath;
-    libPath /= "lib";
-    hipLibPath = libPath.string();
+  else if (!env.hipPathEnv_.empty()) {
+    fs::path p = env.hipLibPathEnv_;
+    p /= "lib";
+    hipLibPath = p.string();
   }
   return hipLibPath;
 }
@@ -500,8 +489,6 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
   bool printLDFlags = 0;       // print HIPLDFLAGS
   bool runCmd = 1;
   bool buildDeps = 0;
-  bool linkType = 1;
-  bool setLinkType = 0;
   string hsacoVersion;
   bool funcSupp = 0;      // enable function support
   bool rdc = 0;           // whether -fgpu-rdc is on
@@ -616,14 +603,13 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
       compileOnly = 1;
       buildDeps = 1;
     }
-    if ((trimarg == "-use-staticlib") && (setLinkType == 0)) {
-      linkType = 0;
-      setLinkType = 1;
-      swallowArg = 1;
+    if ((trimarg == "-use-staticlib")) {
+      std::cerr << "Warning: The -use-staticlib option has been deprecated and is no longer needed.\n";
+      swallowArg = true;
     }
-    if ((trimarg == "-use-sharedlib") && (setLinkType == 0)) {
-      linkType = 1;
-      setLinkType = 1;
+    if ((trimarg == "-use-sharedlib")) {
+      std::cerr << "Warning: The -use-sharedlib option has been deprecated and is no longer needed.\n";
+      swallowArg = true;
     }
     if (hipBinUtilPtr_->stringRegexMatch(arg, "^-O.*")) {
       optArg = arg;
@@ -846,11 +832,6 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
   if (buildDeps) {
     HIPCXXFLAGS += " --cuda-host-only";
   }
-  // Add --hip-link only if it is compile only and -fgpu-rdc is on.
-  if (rdc && !compileOnly) {
-    HIPLDFLAGS += " --hip-link";
-    HIPLDFLAGS += HIPLDARCHFLAGS;
-  }
 
   // hipcc currrently requires separate compilation of source files,
   // ie it is not possible to pass
@@ -884,27 +865,21 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
       HIPCXXFLAGS += hip_device_lib_str;
     }
   }
-  if (os != windows) {
-    HIPLDFLAGS += " -lgcc_s -lgcc -lpthread -lm -lrt";
-  }
 
-  if (os != windows && !compileOnly) {
-    string hipClangVersion, toolArgTemp;
-    if (linkType == 0) {
-      toolArgTemp = " -L"+ hipLibPath + "-lamdhip64 -L" +
-                      roccmPath+ "/lib -lhsa-runtime64 -ldl -lnuma " + toolArgs;
-      toolArgs = toolArgTemp;
-    } else {
-      toolArgTemp =  toolArgs + " -Wl,-rpath=" + hipLibPath + ":"
-                    + roccmPath+"/lib -lamdhip64 ";
-      toolArgs =  toolArgTemp;
+  if (!compileOnly) {
+    string hip_path = getHipLibPath();
+    if (!hip_path.empty()) {
+      HIPLDFLAGS += " -L" + hip_path;
     }
-
-    hipClangVersion = getCompilerVersion();
-    // To support __fp16 and _Float16, explicitly link with compiler-rt
-    toolArgs += " -L" + hipClangPath + "/../lib/clang/" +
-                hipClangVersion + "/lib/linux -lclang_rt.builtins-x86_64 ";
+    HIPLDFLAGS += " --hip-link";
+    if (rdc) {
+      HIPLDFLAGS += HIPLDARCHFLAGS;
+    }
+    if (!windows) {
+      HIPLDFLAGS += "  --rtlib=compiler-rt -unwindlib=libgcc";
+    }
   }
+
   if (!var.hipccCompileFlagsAppendEnv_.empty()) {
     HIPCXXFLAGS += " " + var.hipccCompileFlagsAppendEnv_ + " ";
     HIPCFLAGS += " " + var.hipccCompileFlagsAppendEnv_ + " ";


### PR DESCRIPTION
- deprecate -use-staticlib, -use-sharedlib which no longer provide any functional values
- use --hip-link instead of specifying the HIP runtime by name when linking
- fix linker option bug in HIT test's cmake
- update build options for unit tests requiring pthread or rt

This is essentially a C++ port of this patch in Perl: https://github.com/ROCm-Developer-Tools/HIP/pull/3128