### PR TITLE
[fix][SWDEV-413305][nvcc] Recovering the fallback building of HIP programs via nvcc

### DIFF
--- a/bin/hipcc.pl
+++ b/bin/hipcc.pl
@@ -450,8 +450,9 @@ foreach $arg (@ARGV)
                 if ($HIP_PLATFORM eq "amd") {
                     $hasHIP = 1;
                     $toolArgs .= " -x hip";
-                } else {
+                } elsif ($HIP_PLATFORM eq "nvidia") {
                     $hasCU = 1;
+                    $toolArgs .= " -x cu";
                 }
             }
         }
@@ -530,10 +531,6 @@ if($HIP_PLATFORM eq "amd"){
     }
 
     $ENV{HCC_EXTRA_LIBRARIES}="\n";
-}
-
-if ($HIP_PLATFORM eq 'nvidia') {
-    $HIPCXXFLAGS .= " -x cu";
 }
 
 if ($buildDeps and $HIP_PLATFORM eq 'nvidia') {

--- a/bin/hipcc.pl
+++ b/bin/hipcc.pl
@@ -532,7 +532,7 @@ if($HIP_PLATFORM eq "amd"){
     $ENV{HCC_EXTRA_LIBRARIES}="\n";
 }
 
-if ($hasCXX and $HIP_PLATFORM eq 'nvidia') {
+if ($HIP_PLATFORM eq 'nvidia') {
     $HIPCXXFLAGS .= " -x cu";
 }
 


### PR DESCRIPTION
**[Synopsis]**
+ There is no support for an explicit `-x cu` in hipcc anymore
+ Thus, the building via `nvcc` relies only on `HIP_PLATFORM`, which should be set to `nvidia` in order to invoke `nvcc` compilation with implicit providing `-x cu`
+ But such an implicit setting of `-x cu` never happens
+ As a result, the compilation via `nvcc` starts actually, but ends up with the following error:
`nvcc fatal   : Don't know what to do with 'MatrixTranspose.hip'`

**[Solution]**
+ Not taking into account the excessive variable `$hasCXX` in the condition for an implicit setting of `-x cu`
+ [Reason] `$hasCXX` is never set for the `nvcc` path

**[Testing]**
1. [Linux] To be accomplished by PSDB
2. [Windows] Steps:
- set `HIP_PLATFORM`=nvidia
- set `HIP_PATH`=\<path to ROCM HIP SDK\>
- set `CUDA_PATH`=\<path to NVIDIA CUDA Toolkit\>
- set `path`=c:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.36.32532\bin\Hostx64\x64\;%path%
- perl hipcc.pl MatrixTranspose.hip -o MatrixTranspose -v --gpu-architecture=sm_XX
- run MatrixTranspose.exe

**[Notes]**
- The path to the `MS cl` compiler is needed cause `nvcc` uses it for host compilation
- Setting the `--gpu-architecture` depends on `NVIDIA GPU` to run on
- The execution results are correct according to the margin of error = 0.000001